### PR TITLE
Transforming Node-style APIs into Fantasy-Land Promises

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -1,0 +1,31 @@
+var Promise = require('../index');
+
+/**
+ *
+ * takes a node style API and transforms it into a Fantasy-land Promise
+ * @example:
+ * var fs = require("fs");
+ * var node = require("fantasy-promises/node");
+ * var p = node.call(fs.readFile,'./myfile.js', 'UTF-8');
+ * p.fork(
+ *        function(d) {console.log(d)},
+ *        function(err) {console.log(err)},
+ * );
+ */
+
+var slice = [].slice;
+
+exports.apply = function apply(func, args) {
+  return new Promise(function (resolve, reject) {
+    var callback = function (err, data) {
+      if(err) return reject(error);
+      resolve(data);
+    }
+    func.apply(null, args.concat(callback));
+  });
+}
+
+exports.call = function call(func) {
+  return exports.apply(func, slice.call(arguments, 1));
+}
+

--- a/test.js
+++ b/test.js
@@ -35,6 +35,7 @@ exports.testOf = function(test) {
     );
 };
 
+
 exports.testError = function(test) {
     var promise = Promise.error(41);
     promise.fork(
@@ -132,3 +133,32 @@ exports.testJoin = function(test) {
         }
     );
 };
+exports.testNodeCall = function(test) {
+   var node = require('./node');
+   var promise = node.call(fs.readFile,__filename, 'UTF-8');
+   promise.fork(
+         function(data) {
+            test.equal(true, data.indexOf("exports.testNode = function(test)") != -1);
+            test.done();
+         },
+         function(err) { 
+            test.ok(false, 'node.call was reject');
+            test.done();
+         }
+    );
+};
+exports.testNodeApply = function(test) {
+   var node = require('./node');
+   var promise = node.apply(fs.readFile, [__filename, 'UTF-8']);
+   promise.fork(
+         function(data) {
+            test.equal(true, data.indexOf("exports.testNode = function(test)") != -1);
+            test.done();
+         },
+         function(err) { 
+            test.ok(false, 'node.apply was reject');
+            test.done();
+         }
+    );
+};
+


### PR DESCRIPTION
usage:

```
var fs = require("fs");
var node = require("fantasy-promises/node");
var p = node.call(fs.readFile,'./myfile.js', 'UTF-8');
p.fork(
     function(d) {console.log(d)},
     function(err) {console.log(err)},
 );
var pApply = node.apply(fs.readFile,['./myfile.js', 'UTF-8']);
pApply.fork(
     function(d) {console.log(d)},
     function(err) {console.log(err)},
 );
```
