### PR TITLE
Updating the lib to be more consistent with other fantasy land repos

### DIFF
--- a/fantasy-promises.js
+++ b/fantasy-promises.js
@@ -1,4 +1,4 @@
-var Promise = require('./src/promise');
+const Promise = require('./src/promise');
 
 if (typeof module != 'undefined')
     module.exports = Promise;

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "grunt": "0.4.x",
     "grunt-contrib-jshint": "0.6.x",
     "grunt-contrib-nodeunit": "0.2.0",
-    "fantasy-check": "0.0.8",
+    "fantasy-check": "0.1.6",
     "fantasy-helpers": "0.0.x",
     "fantasy-combinators": "0.0.x",
-    "fantasy-io": "0.0.x"
+    "fantasy-identities": "0.x.x"
   },
   "scripts": {
       "readme": "$(npm bin)/emu < src/promise.js > README.md",
@@ -38,5 +38,5 @@
   },
   "files": ["fantasy-promises.js", "src/*.js"],
   "main": "fantasy-promises.js",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/package.json
+++ b/package.json
@@ -20,21 +20,21 @@
     "url": "https://github.com/fantasyland/fantasy-promises/issues"
   },
   "dependencies": {
-    "daggy": "0.0.x"
+    "daggy": "0.0.x",
+    "fantasy-combinators": "0.0.x"
   },
   "devDependencies": {
     "grunt-cli": "0.1.9",
     "grunt": "0.4.x",
-    "grunt-contrib-jshint": "0.6.x",
-    "grunt-contrib-nodeunit": "0.2.0",
+    "grunt-contrib-jshint": "0.11.x",
+    "grunt-contrib-nodeunit": "0.4.x",
     "fantasy-check": "0.1.6",
     "fantasy-helpers": "0.0.x",
-    "fantasy-combinators": "0.0.x",
     "fantasy-identities": "0.x.x"
   },
   "scripts": {
       "readme": "$(npm bin)/emu < src/promise.js > README.md",
-      "test": "grunt"
+      "test": "node --harmony_destructuring node_modules/.bin/nodeunit test/*.js"
   },
   "files": ["fantasy-promises.js", "src/*.js"],
   "main": "fantasy-promises.js",

--- a/src/promise.js
+++ b/src/promise.js
@@ -1,4 +1,5 @@
-var daggy = require('daggy');
+const daggy = require('daggy');
+const {identity} = require('fantasy-combinators');
 /**
     # Fantasy Promises
 
@@ -15,7 +16,7 @@ var daggy = require('daggy');
 
     The `resolve` callback gets called on a value.
 **/
-var Promise = daggy.tagged('fork');
+const Promise = daggy.tagged('fork');
 
 /**
     ### `Promise.of(x)`
@@ -23,9 +24,7 @@ var Promise = daggy.tagged('fork');
     Creates a Promise that contains a successful value.
 **/
 Promise.of = function(x) {
-    return Promise(function(resolve) {
-        return resolve(x);
-    });
+    return Promise((resolve) => resolve(x));
 };
 
 /**
@@ -35,11 +34,8 @@ Promise.of = function(x) {
     through to the resolve function.
 **/
 Promise.prototype.ap = function(a) {
-    var promise = this;
-    return Promise(function(resolve) {
-        return promise.fork(function(f) {
-            return a.map(f).fork(resolve);
-        });
+    return Promise((resolve) => {
+        return this.fork((f) => a.map(f).fork(resolve));
     });
 };
 
@@ -50,11 +46,8 @@ Promise.prototype.ap = function(a) {
     is successfully fulfilled. `f` must return a new promise.
 **/
 Promise.prototype.chain = function(f) {
-    var promise = this;
-    return Promise(function(resolve) {
-        return promise.fork(function(a) {
-            return f(a).fork(resolve);
-        });
+    return Promise((resolve) => {
+        return this.fork((a) => f(a).fork(resolve));
     });
 };
 
@@ -65,11 +58,8 @@ Promise.prototype.chain = function(f) {
     through to the resolve function.
 **/
 Promise.prototype.map = function(f) {
-    var promise = this;
-    return Promise(function(resolve) {
-        return promise.fork(function(a) {
-            return resolve(f(a));
-        });
+    return Promise((resolve) => {
+        return this.fork((a) => resolve(f(a)));
     });
 };
 
@@ -79,9 +69,7 @@ Promise.prototype.map = function(f) {
    Executes a promise to get a value.
 **/
 Promise.prototype.extract = function() {
-    return this.fork(function(data) {
-        return data;
-    });
+    return this.fork(identity);
 };
 
 /**
@@ -91,10 +79,7 @@ Promise.prototype.extract = function() {
    value.
 **/
 Promise.prototype.extend = function(f) {
-    var promise = this;
-    return promise.map(function(a) {
-        return f(Promise.of(a));
-    });
+    return this.map((a) => f(Promise.of(a)));
 };
 
 // Export

--- a/src/promise.js
+++ b/src/promise.js
@@ -23,7 +23,7 @@ var Promise = daggy.tagged('fork');
     Creates a Promise that contains a successful value.
 **/
 Promise.of = function(x) {
-    return new Promise(function(resolve) {
+    return Promise(function(resolve) {
         return resolve(x);
     });
 };
@@ -36,7 +36,7 @@ Promise.of = function(x) {
 **/
 Promise.prototype.chain = function(f) {
     var promise = this;
-    return new Promise(function(resolve) {
+    return Promise(function(resolve) {
         return promise.fork(function(a) {
             return f(a).fork(resolve);
         });
@@ -51,7 +51,7 @@ Promise.prototype.chain = function(f) {
 **/
 Promise.prototype.map = function(f) {
     var promise = this;
-    return new Promise(function(resolve) {
+    return Promise(function(resolve) {
         return promise.fork(function(a) {
             return resolve(f(a));
         });

--- a/src/promise.js
+++ b/src/promise.js
@@ -29,6 +29,21 @@ Promise.of = function(x) {
 };
 
 /**
+    ### `ap(x)`
+
+    Returns a new promise that evaluates `f` on a value and passes it
+    through to the resolve function.
+**/
+Promise.prototype.ap = function(a) {
+    var promise = this;
+    return Promise(function(resolve) {
+        return promise.fork(function(f) {
+            return a.map(f).fork(resolve);
+        });
+    });
+};
+
+/**
     ### `chain(f)`
 
     Returns a new promise that evaluates `f` when the current promise

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,13 +1,11 @@
-var λ = require('fantasy-check/src/adapters/nodeunit'),
-    applicative = require('fantasy-check/src/laws/applicative'),
-    functor = require('fantasy-check/src/laws/functor'),
-    monad = require('fantasy-check/src/laws/monad'),
+const λ = require('fantasy-check/src/adapters/nodeunit');
+const applicative = require('fantasy-check/src/laws/applicative');
+const functor = require('fantasy-check/src/laws/functor');
+const monad = require('fantasy-check/src/laws/monad');
     
-    combinators = require('fantasy-combinators'),
-    Identity = require('fantasy-identities'),
-    Promise = require('../fantasy-promises'),
-
-    identity = combinators.identity;
+const {identity} = require('fantasy-combinators');
+const Identity = require('fantasy-identities');
+const Promise = require('../fantasy-promises');
 
 function run(a) {
     return Identity.of(a.fork(identity));
@@ -35,12 +33,8 @@ exports.promise = {
 
     // Manual tests
     'when testing extend should return correct value': λ.check(
-        function(a) {
-            var promise = Promise.of(a).extend(
-                function(x) {
-                    return x.extract().toUpperCase();
-                }
-            );
+        (a) => {
+            const promise = Promise.of(a).extend((x) => x.extract().toUpperCase());
             return promise.extract() === a.toUpperCase();
         },
         [String]

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,60 +1,31 @@
 var λ = require('fantasy-check/src/adapters/nodeunit'),
+    functor = require('fantasy-check/src/laws/functor'),
+    monad = require('fantasy-check/src/laws/monad'),
+    
     combinators = require('fantasy-combinators'),
-    IO = require('fantasy-io'),
+    Identity = require('fantasy-identities'),
     Promise = require('../fantasy-promises'),
-
-    fs = require('fs'),
 
     identity = combinators.identity;
 
+function run(a) {
+    return Identity.of(a.fork(identity));
+}
+
 exports.promise = {
-    'when testing of should return correct value': λ.check(
-        function(a) {
-            var promise = Promise.of(a);
-            return promise.fork(identity) === a;
-        },
-        [λ.AnyVal]
-    ),
-    'when testing chain should return correct value': λ.check(
-        function(a) {
-            var promise = Promise.of(a).chain(
-                function(x) {
-                    return Promise.of(x + 1);
-                }
-            );
-            return promise.fork(identity) === a + 1;
-        },
-        [Number]
-    ),
-    'when testing map should return correct value': λ.check(
-        function(a) {
-            var promise = Promise.of(a).map(
-                function(x) {
-                    return x + 1;
-                }
-            );
-            return promise.fork(identity) === a + 1;
-        },
-        [Number]
-    ),
-    'when testing nested promises with chain should return correct value': λ.check(
-        function(a) {
-            var promise = Promise.of(Promise.of(a)).chain(identity);
-            return promise.fork(identity) === a;
-        },
-        [λ.AnyVal]
-    ),
-    'when testing extract should return correct value': λ.check(
-        function(a) {
-            var promise = Promise.of(a).map(
-                function(x) {
-                    return x + 1;
-                }
-            );
-            return promise.extract() === a + 1;
-        },
-        [Number]
-    ),
+
+    // Functor tests
+    'All (Functor)': functor.laws(λ)(Promise.of, run),
+    'Identity (Functor)': functor.identity(λ)(Promise.of, run),
+    'Composition (Functor)': functor.composition(λ)(Promise.of, run),
+
+    // Monad tests
+    'All (Monad)': monad.laws(λ)(Promise, run),
+    'Left Identity (Monad)': monad.leftIdentity(λ)(Promise, run),
+    'Right Identity (Monad)': monad.rightIdentity(λ)(Promise, run),
+    'Associativity (Monad)': monad.associativity(λ)(Promise, run),
+
+    // Manual tests
     'when testing extend should return correct value': λ.check(
         function(a) {
             var promise = Promise.of(a).extend(
@@ -66,30 +37,4 @@ exports.promise = {
         },
         [String]
     )
-};
-
-exports.testReadFile = function(test) {
-    var promise = new Promise(function(resolve) {
-        fs.readFile(__filename, 'utf8', function(error, data) {
-            resolve(data);
-        });
-    });
-
-    promise.fork(function(data) {
-        test.ok(true);
-        test.done();
-    });
-};
-
-exports.testExtend = function(test) {
-    var promise = new Promise(function(resolve) {
-        setTimeout(function() {
-            resolve("100 ms");
-        }, 100);
-    }).extend(function(p) {
-        return p.extract().toUpperCase();
-    }).fork(function(data) {
-        test.equal("100 MS", data);
-        test.done();
-    });
 };

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,4 +1,5 @@
 var λ = require('fantasy-check/src/adapters/nodeunit'),
+    applicative = require('fantasy-check/src/laws/applicative'),
     functor = require('fantasy-check/src/laws/functor'),
     monad = require('fantasy-check/src/laws/monad'),
     
@@ -13,6 +14,13 @@ function run(a) {
 }
 
 exports.promise = {
+
+    // Applicative Functor tests
+    'All (Applicative)': applicative.laws(λ)(Promise, run),
+    'Identity (Applicative)': applicative.identity(λ)(Promise, run),
+    'Composition (Applicative)': applicative.composition(λ)(Promise, run),
+    'Homomorphism (Applicative)': applicative.homomorphism(λ)(Promise, run),
+    'Interchange (Applicative)': applicative.interchange(λ)(Promise, run),
 
     // Functor tests
     'All (Functor)': functor.laws(λ)(Promise.of, run),


### PR DESCRIPTION
Update the tests to use fantasy-check …
- Removed the new keyword as we're using daggy and it's no longer required.
- Adding functor and monad test (should promise have ap, so we can test applicative functors?)

Adding ap promise. …
- Not entirely sure if ap is actually viable in this context, but it does seem to pass Applicative laws, which means either it does pass or the laws aren't well executed!?