### PR TITLE
Add semigroup instance for Promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,19 +24,23 @@
     "fantasy-combinators": "0.0.x"
   },
   "devDependencies": {
-    "grunt-cli": "0.1.9",
-    "grunt": "0.4.x",
-    "grunt-contrib-jshint": "0.11.x",
-    "grunt-contrib-nodeunit": "0.4.x",
     "fantasy-check": "0.1.6",
     "fantasy-helpers": "0.0.x",
-    "fantasy-identities": "0.x.x"
+    "fantasy-identities": "0.x.x",
+    "fantasy-sorcery": "0.0.1",
+    "grunt": "0.4.x",
+    "grunt-cli": "0.1.9",
+    "grunt-contrib-jshint": "0.11.x",
+    "grunt-contrib-nodeunit": "0.4.x"
   },
   "scripts": {
-      "readme": "$(npm bin)/emu < src/promise.js > README.md",
-      "test": "node --harmony_destructuring node_modules/.bin/nodeunit test/*.js"
+    "readme": "$(npm bin)/emu < src/promise.js > README.md",
+    "test": "node node_modules/.bin/nodeunit test/*.js"
   },
-  "files": ["fantasy-promises.js", "src/*.js"],
+  "files": [
+    "fantasy-promises.js",
+    "src/*.js"
+  ],
   "main": "fantasy-promises.js",
   "version": "0.1.2"
 }

--- a/src/promise.js
+++ b/src/promise.js
@@ -1,5 +1,6 @@
 const daggy = require('daggy');
 const {identity} = require('fantasy-combinators');
+const {append, lift2} = require('fantasy-sorcery');
 /**
     # Fantasy Promises
 
@@ -49,6 +50,18 @@ Promise.prototype.chain = function(f) {
     return Promise((resolve) => {
         return this.fork((a) => f(a).fork(resolve));
     });
+};
+
+/**
+    ### `concat(that)`
+
+    Returns a new promise that, if both this promise and the given
+    promise resolve, returns the two results concatenated together.
+    Note that `this` and `that` must both return a particular
+    semigroup.
+**/
+Promise.prototype.concat = function(that) {
+    return lift2(append, this, that);
 };
 
 /**

--- a/test/promise.js
+++ b/test/promise.js
@@ -2,7 +2,8 @@ const λ = require('fantasy-check/src/adapters/nodeunit');
 const applicative = require('fantasy-check/src/laws/applicative');
 const functor = require('fantasy-check/src/laws/functor');
 const monad = require('fantasy-check/src/laws/monad');
-    
+const semigroup = require('fantasy-check/src/laws/semigroup');
+
 const {identity} = require('fantasy-combinators');
 const Identity = require('fantasy-identities');
 const Promise = require('../fantasy-promises');
@@ -30,6 +31,10 @@ exports.promise = {
     'Left Identity (Monad)': monad.leftIdentity(λ)(Promise, run),
     'Right Identity (Monad)': monad.rightIdentity(λ)(Promise, run),
     'Associativity (Monad)': monad.associativity(λ)(Promise, run),
+
+    // Semigroup tests
+    'All (Semigroup)': semigroup.laws(λ)(Promise.of, run),
+    'Associativity (Semigroup)': semigroup.associativity(λ)(Promise.of, run),
 
     // Manual tests
     'when testing extend should return correct value': λ.check(


### PR DESCRIPTION
Every applicative functor gives rise to a monoid. Unfortunately, mempty is a real hassle in JavaScript, so I'm just going to add the semigroup instance for now.

I've added tests, but they're failing as I can't work out how to restrict fantasy-check to using only valid FL semigroups for its input. Any help would be greatly appreciated!

PS. is it a design choice that there is no error parameter? Is it intended to be stacked with something like `Either`? Only asking as I went to add `alt` as well, but I then noticed there's no rejection branch!